### PR TITLE
Rename Snail tab(s)

### DIFF
--- a/src/gui/ui/dockwidget.ui
+++ b/src/gui/ui/dockwidget.ui
@@ -22,7 +22,7 @@
       </property>
       <widget class="QWidget" name="mTabSystem">
        <attribute name="title">
-        <string>System</string>
+        <string>QGIS</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,2">
         <item>

--- a/src/gui/ui/settingswidget.ui
+++ b/src/gui/ui/settingswidget.ui
@@ -21,7 +21,7 @@
      </property>
      <widget class="QWidget" name="System">
       <attribute name="title">
-       <string>System</string>
+       <string>QGIS</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>


### PR DESCRIPTION
Simply renaming the current "System" tabs to "QGIS" to match the discussion in Issue #4